### PR TITLE
Generate correct choices of people for a single week

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gem "rspec"
+
+group :development do
+  gem "pry"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.0)
     diff-lcs (1.2.5)
+    method_source (0.8.2)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -14,9 +20,11 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    slop (3.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry
   rspec

--- a/lib/people_collection_factory.rb
+++ b/lib/people_collection_factory.rb
@@ -1,20 +1,32 @@
 require "ostruct"
 
 class PeopleCollectionFactory
-  def initialize(input_data)
-    @input_data = input_data
+  def initialize(people_inputs, deploy_access_inputs)
+    @people_inputs = people_inputs
+    @people_with_deploy_access = production_access_use_names(deploy_access_inputs)
   end
 
   def call
-    input_data.map do |person_hash|
-      build_person(person_hash)
+    @people_inputs.map do |person_hash|
+      build_person(
+        person_hash,
+        deploy_access?(person_hash[:use_name]),
+      )
     end
   end
 
 private
-  attr_reader :input_data
+  def build_person(person_hash, has_production_access)
+    OpenStruct.new(
+      person_hash.merge(production_access: has_production_access)
+    )
+  end
 
-  def build_person(person_hash)
-    OpenStruct.new(person_hash)
+  def production_access_use_names(raw_deploy_access_inputs)
+    raw_deploy_access_inputs.map { |p| p[:use_name] }
+  end
+
+  def deploy_access?(person_use_name)
+    @people_with_deploy_access.include? person_use_name
   end
 end

--- a/lib/people_collection_factory.rb
+++ b/lib/people_collection_factory.rb
@@ -1,12 +1,20 @@
+require "ostruct"
+
 class PeopleCollectionFactory
   def initialize(input_data)
     @input_data = input_data
   end
 
   def call
-    []
+    input_data.map do |person_hash|
+      build_person(person_hash)
+    end
   end
 
 private
   attr_reader :input_data
+
+  def build_person(person_hash)
+    OpenStruct.new(person_hash)
+  end
 end

--- a/lib/rota_week_builder.rb
+++ b/lib/rota_week_builder.rb
@@ -20,16 +20,24 @@ private
             #{production_access ? "with production access" : ""}!"
     end
     eligible_people.sample.tap do |chosen_person|
-      chosen_people.push chosen_person
+      make_ineligible(team_members(chosen_person.team))
     end
   end
 
-  def available_people(role, production_access)
-    people_with_role_and_access(role, production_access) - chosen_people
+  def team_members(team_name)
+    @people.select { |p| p.team == team_name }
   end
 
-  def chosen_people
-    @chosen_people ||= []
+  def available_people(role, production_access)
+    people_with_role_and_access(role, production_access) - ineligible_people
+  end
+
+  def ineligible_people
+    @ineligible_people ||= []
+  end
+
+  def make_ineligible(people)
+    @ineligible_people = ineligible_people + people
   end
 
   def people_with_role_and_access(role, production_access)

--- a/lib/rota_week_builder.rb
+++ b/lib/rota_week_builder.rb
@@ -6,32 +6,38 @@ class RotaWeekBuilder
   def call
     RotaWeek.new(
       :web_ops => pick_person("webops"),
-      :dev => pick_person("developer"),
+      :dev => pick_person("developer", true),
       :supplemental_dev => pick_person("developer"),
     )
   end
 
 private
 
-  def pick_person(role)
-    people_with_role = available_people(role)
-    raise "No more people to pick for role #{role}!" if people_with_role.empty?
-
-    people_with_role.sample.tap do |chosen_person|
+  def pick_person(role, production_access=false)
+    eligible_people = available_people(role, production_access)
+    if eligible_people.empty?
+      raise "No more people to pick for role #{role}
+            #{production_access ? "with production access" : ""}!"
+    end
+    eligible_people.sample.tap do |chosen_person|
       chosen_people.push chosen_person
     end
   end
 
-  def available_people(role)
-    people_with_role(role) - chosen_people
+  def available_people(role, production_access)
+    people_with_role_and_access(role, production_access) - chosen_people
   end
 
   def chosen_people
     @chosen_people ||= []
   end
 
-  def people_with_role(role)
-    @people.select { |p| p.rota_skill_group == role }
+  def people_with_role_and_access(role, production_access)
+    result = @people.dup
+    if production_access
+      result = result.select { |p| p.production_access == true }
+    end
+    result.select { |p| p.rota_skill_group == role }
   end
 
 end

--- a/lib/rota_week_builder.rb
+++ b/lib/rota_week_builder.rb
@@ -1,0 +1,50 @@
+class RotaWeekBuilder
+  def initialize(people)
+    @people = people
+  end
+
+  def call
+    RotaWeek.new(
+      :web_ops => pick_person,
+      :dev => pick_person,
+      :supplemental_dev => pick_person,
+    )
+  end
+
+private
+
+  def pick_person
+    raise "No more people to pick!" if available_people.empty?
+
+    available_people.sample.tap do |chosen_person|
+      chosen_people.push chosen_person
+    end
+  end
+
+  def available_people
+    @people - chosen_people
+  end
+
+  def chosen_people
+    @chosen_people ||= []
+  end
+
+end
+
+class RotaWeek
+  include Enumerable
+
+  attr_reader :web_ops, :dev, :supplemental_dev
+
+  def initialize(web_ops:, dev:, supplemental_dev:)
+    @web_ops = web_ops
+    @dev = dev
+    @supplemental_dev = supplemental_dev
+  end
+
+  def each
+    yield web_ops
+    yield dev
+    yield supplemental_dev
+  end
+end

--- a/lib/rota_week_builder.rb
+++ b/lib/rota_week_builder.rb
@@ -5,28 +5,33 @@ class RotaWeekBuilder
 
   def call
     RotaWeek.new(
-      :web_ops => pick_person,
-      :dev => pick_person,
-      :supplemental_dev => pick_person,
+      :web_ops => pick_person("webops"),
+      :dev => pick_person("developer"),
+      :supplemental_dev => pick_person("developer"),
     )
   end
 
 private
 
-  def pick_person
-    raise "No more people to pick!" if available_people.empty?
+  def pick_person(role)
+    people_with_role = available_people(role)
+    raise "No more people to pick for role #{role}!" if people_with_role.empty?
 
-    available_people.sample.tap do |chosen_person|
+    people_with_role.sample.tap do |chosen_person|
       chosen_people.push chosen_person
     end
   end
 
-  def available_people
-    @people - chosen_people
+  def available_people(role)
+    people_with_role(role) - chosen_people
   end
 
   def chosen_people
     @chosen_people ||= []
+  end
+
+  def people_with_role(role)
+    @people.select { |p| p.rota_skill_group == role }
   end
 
 end

--- a/spec/helpers/test_penguin_factories.rb
+++ b/spec/helpers/test_penguin_factories.rb
@@ -1,0 +1,73 @@
+module TestPenguinFactories
+  class ColonyFactory
+    include RSpec::Mocks
+
+    def initialize(generator)
+      @generator = generator
+    end
+
+    def call(teams:, test_penguin_team_factory:)
+      result = []
+
+      teams.times do |i|
+        result += test_penguin_team_factory.call("team_#{i}")
+      end
+
+      result
+    end
+  end
+
+  class TeamFactory
+    include RSpec::Mocks
+
+    def initialize(generator, webops:, developers_with_prod:, developers_without_prod:)
+      @generator = generator
+      @webops = webops
+      @developers_with_prod = developers_with_prod
+      @developers_without_prod = developers_without_prod
+    end
+
+    def call(team_name = "team_name")
+      result = []
+
+      @webops.times do
+        result << webops_penguin_factory.call(team_name)
+      end
+
+      @developers_with_prod.times do
+        result << developers_penguin_factory.call(team_name, true)
+      end
+
+      @developers_without_prod.times do
+        result << developers_penguin_factory.call(team_name, false)
+      end
+
+      result
+    end
+
+  private
+    def webops_penguin_factory
+      ->(team_name) {
+        double(:webops_penguin,
+          team: team_name,
+          rota_skill_group: "webops",
+          production_access: true,
+        )
+      }
+    end
+
+    def developers_penguin_factory
+      ->(team_name, production_access) {
+        double(:developer_penguin,
+          team: team_name,
+          rota_skill_group: "developer",
+          production_access: production_access,
+        )
+      }
+    end
+
+    def double(symbol, *args)
+      @generator.call(symbol, *args)
+    end
+  end
+end

--- a/spec/people_collection_factory_spec.rb
+++ b/spec/people_collection_factory_spec.rb
@@ -1,17 +1,19 @@
 require 'people_collection_factory'
 
 describe PeopleCollectionFactory do 
+  let(:names) { ["Penguin", "Polar bear"] }
+
   let(:input_data) {
     [
       {
-        :name                 => "Penguin", 
+        :name                 => names.first,
         :team                 => "GOV.UK",
         :"production-access"  => "yes",
         :"tech-lead"          => "yes",
         :"role"               => "developer",
       },
       {
-        :name                 => "Polar bear", 
+        :name                 => names.last,
         :team                 => "IDA",
         :"production-access"  => "no",
         :"tech-lead"          => "no",
@@ -22,7 +24,12 @@ describe PeopleCollectionFactory do
 
   subject(:factory) { described_class.new(input_data) }
 
-  it "returns a collection" do
-    expect(factory.call).to respond_to :[]
+  it "returns a collection of objects representing the input data" do
+    result = factory.call
+    first_result = result[0]
+
+    expect(result).to respond_to :[]
+    expect(result.size).to eq(2)
+    expect(names).to include(first_result.name)
   end
 end

--- a/spec/people_collection_factory_spec.rb
+++ b/spec/people_collection_factory_spec.rb
@@ -1,28 +1,46 @@
 require 'people_collection_factory'
 
-describe PeopleCollectionFactory do 
-  let(:names) { ["Penguin", "Polar bear"] }
+describe PeopleCollectionFactory do
+  let(:names) { ["Blue Penguin", "Red Penguin"] }
+  let(:use_names) { ["B Penguin", "R Penguin"] }
+  let(:blue_penguin_hash) {
+    {
+      :full_name        => names.first,
+      :use_name         => use_names.first,
+      :rota_skill_group => "developer",
+      :team             => "User Formats",
+    }
+  }
+  let(:red_penguin_hash) {
+    {
+      :full_name        => names[1],
+      :use_name         => use_names[1],
+      :rota_skill_group => "webops",
+      :team             => "Product Gaps",
+    }
+  }
 
-  let(:input_data) {
+  #When this data is available, this will contain
+  #information about whether person is tech lead or not
+  let(:people_input_data) {
     [
-      {
-        :name                 => names.first,
-        :team                 => "GOV.UK",
-        :"production-access"  => "yes",
-        :"tech-lead"          => "yes",
-        :"role"               => "developer",
-      },
-      {
-        :name                 => names.last,
-        :team                 => "IDA",
-        :"production-access"  => "no",
-        :"tech-lead"          => "no",
-        :"role"               => "webops",
-      },
+      blue_penguin_hash,
+      red_penguin_hash,
     ]
   }
 
-  subject(:factory) { described_class.new(input_data) }
+  let(:deploy_access_input_data) {
+    [
+      red_penguin_hash,
+    ]
+  }
+
+  subject(:factory) {
+    described_class.new(
+      people_input_data,
+      deploy_access_input_data
+    )
+  }
 
   it "returns a collection of objects representing the input data" do
     result = factory.call
@@ -30,6 +48,14 @@ describe PeopleCollectionFactory do
 
     expect(result).to respond_to :[]
     expect(result.size).to eq(2)
-    expect(names).to include(first_result.name)
+    expect(names).to include(first_result.full_name)
+  end
+
+  it "correctly determines production access" do
+    result = factory.call
+    with_production_access = result.select { |p| p.production_access == true }
+
+    expect(with_production_access.size).to eq(1)
+    expect(with_production_access.first.use_name).to eq("R Penguin")
   end
 end

--- a/spec/rota_week_builder_spec.rb
+++ b/spec/rota_week_builder_spec.rb
@@ -82,11 +82,10 @@ describe RotaWeekBuilder do
     expect(result.supplemental_dev.rota_skill_group).to eq("developer")
   end
 
-  it "returns at least one developer with production access" do
+  it "returns a primary dev with production access" do
     result = subject.call
-    devs = [result.dev, result.supplemental_dev]
 
-    expect(devs.map(&:production_access)).to include true
+    expect(result.dev.production_access).to be true
   end
 
   context "with two people" do

--- a/spec/rota_week_builder_spec.rb
+++ b/spec/rota_week_builder_spec.rb
@@ -1,0 +1,33 @@
+require "rota_week_builder"
+
+describe RotaWeekBuilder do
+  let(:red_penguin) { double(:red_penguin) }
+  let(:blue_penguin) { double(:blue_penguin) }
+  let(:yellow_penguin) { double(:yellow_penguin) }
+  let(:penguins) { [red_penguin, blue_penguin, yellow_penguin] }
+
+  subject(:builder) { RotaWeekBuilder.new(penguins) }
+
+  it "returns a collection for the next week" do
+    result = subject.call
+    expect(result.web_ops).not_to be(nil)
+    expect(result.dev).not_to be(nil)
+    expect(result.supplemental_dev).not_to be(nil)
+
+    expect(result.count).to eq(3)
+  end
+
+  it "returns three different people" do
+    result = subject.call
+    people = result.map.to_a
+    expect(people.uniq.size).to eq(3)
+  end
+
+  context "with two people" do
+    let(:penguins) { [red_penguin, yellow_penguin] }
+
+    it "raises if not provided with enough people" do
+      expect { subject.call }.to raise_error
+    end
+  end
+end

--- a/spec/rota_week_builder_spec.rb
+++ b/spec/rota_week_builder_spec.rb
@@ -1,10 +1,62 @@
 require "rota_week_builder"
 
+class TestPenguinFactory
+  include RSpec::Mocks
+
+  def initialize(generator)
+    @generator = generator
+  end
+
+  def call(webops:, developers_with_prod:, developers_without_prod:)
+    result = []
+
+    webops.times do
+      result << webops_penguin_factory.call
+    end
+
+    developers_with_prod.times do
+      result << developers_penguin_factory.call(true)
+    end
+
+    developers_without_prod.times do
+      result << developers_penguin_factory.call(false)
+    end
+
+    result
+  end
+
+private
+  def webops_penguin_factory
+    ->() {
+      double(:webops_penguin,
+        rota_skill_group: "webops",
+        production_access: true,
+      )
+    }
+  end
+
+  def developers_penguin_factory
+    ->(production_access) {
+      double(:developer_penguin,
+        rota_skill_group: "developer",
+        production_access: production_access,
+      )
+    }
+  end
+
+  def double(symbol, *args)
+    @generator.call(symbol, *args)
+  end
+end
+
 describe RotaWeekBuilder do
-  let(:red_penguin) { double(:red_penguin) }
-  let(:blue_penguin) { double(:blue_penguin) }
-  let(:yellow_penguin) { double(:yellow_penguin) }
-  let(:penguins) { [red_penguin, blue_penguin, yellow_penguin] }
+  let(:penguins) {
+    TestPenguinFactory.new(method(:double)).call(
+      webops: 2,
+      developers_with_prod: 2,
+      developers_without_prod: 10,
+    )
+  }
 
   subject(:builder) { RotaWeekBuilder.new(penguins) }
 
@@ -13,7 +65,6 @@ describe RotaWeekBuilder do
     expect(result.web_ops).not_to be(nil)
     expect(result.dev).not_to be(nil)
     expect(result.supplemental_dev).not_to be(nil)
-
     expect(result.count).to eq(3)
   end
 
@@ -23,8 +74,29 @@ describe RotaWeekBuilder do
     expect(people.uniq.size).to eq(3)
   end
 
+  it "returns people of the right role for their allocated job" do
+    result = subject.call
+
+    expect(result.web_ops.rota_skill_group).to eq("webops")
+    expect(result.dev.rota_skill_group).to eq("developer")
+    expect(result.supplemental_dev.rota_skill_group).to eq("developer")
+  end
+
+  it "returns at least one developer with production access" do
+    result = subject.call
+    devs = [result.dev, result.supplemental_dev]
+
+    expect(devs.map(&:production_access)).to include true
+  end
+
   context "with two people" do
-    let(:penguins) { [red_penguin, yellow_penguin] }
+    let(:penguins) {
+      TestPenguinFactory.new(method(:double)).call(
+        webops: 1,
+        developers_with_prod: 0,
+        developers_without_prod: 1,
+      )
+    }
 
     it "raises if not provided with enough people" do
       expect { subject.call }.to raise_error

--- a/spec/rota_week_builder_spec.rb
+++ b/spec/rota_week_builder_spec.rb
@@ -1,67 +1,25 @@
 require "rota_week_builder"
-
-class TestPenguinFactory
-  include RSpec::Mocks
-
-  def initialize(generator)
-    @generator = generator
-  end
-
-  def call(webops:, developers_with_prod:, developers_without_prod:)
-    result = []
-
-    webops.times do
-      result << webops_penguin_factory.call
-    end
-
-    developers_with_prod.times do
-      result << developers_penguin_factory.call(true)
-    end
-
-    developers_without_prod.times do
-      result << developers_penguin_factory.call(false)
-    end
-
-    result
-  end
-
-private
-  def webops_penguin_factory
-    ->() {
-      double(:webops_penguin,
-        rota_skill_group: "webops",
-        production_access: true,
-      )
-    }
-  end
-
-  def developers_penguin_factory
-    ->(production_access) {
-      double(:developer_penguin,
-        rota_skill_group: "developer",
-        production_access: production_access,
-      )
-    }
-  end
-
-  def double(symbol, *args)
-    @generator.call(symbol, *args)
-  end
-end
+require "helpers/test_penguin_factories"
 
 describe RotaWeekBuilder do
   let(:penguins) {
-    TestPenguinFactory.new(method(:double)).call(
+    test_penguin_team_factory = TestPenguinFactories::TeamFactory.new(
+      method(:double),
       webops: 2,
       developers_with_prod: 2,
       developers_without_prod: 10,
+    )
+    TestPenguinFactories::ColonyFactory.new(method(:double)).call(
+      teams: 3,
+      test_penguin_team_factory: test_penguin_team_factory,
     )
   }
 
   subject(:builder) { RotaWeekBuilder.new(penguins) }
 
+  let(:result) { subject.call }
+
   it "returns a collection for the next week" do
-    result = subject.call
     expect(result.web_ops).not_to be(nil)
     expect(result.dev).not_to be(nil)
     expect(result.supplemental_dev).not_to be(nil)
@@ -69,32 +27,34 @@ describe RotaWeekBuilder do
   end
 
   it "returns three different people" do
-    result = subject.call
     people = result.map.to_a
     expect(people.uniq.size).to eq(3)
   end
 
   it "returns people of the right role for their allocated job" do
-    result = subject.call
-
     expect(result.web_ops.rota_skill_group).to eq("webops")
     expect(result.dev.rota_skill_group).to eq("developer")
     expect(result.supplemental_dev.rota_skill_group).to eq("developer")
   end
 
   it "returns a primary dev with production access" do
-    result = subject.call
-
     expect(result.dev.production_access).to be true
+  end
+
+  it "returns people from different teams" do
+    people = [result.dev, result.supplemental_dev, result.web_ops]
+
+    expect(people.map(&:team).uniq.size).to eq 3
   end
 
   context "with two people" do
     let(:penguins) {
-      TestPenguinFactory.new(method(:double)).call(
+      TestPenguinFactories::TeamFactory.new(
+        method(:double),
         webops: 1,
         developers_with_prod: 0,
         developers_without_prod: 1,
-      )
+      ).call
     }
 
     it "raises if not provided with enough people" do


### PR DESCRIPTION
[Pivotal ticket](https://www.pivotaltracker.com/story/show/79427332)

This adds a `PeopleCollectionFactory` responsible for taking in two hashes containing available information about people -- their basic information (including job role), and whether or not they have production access.

The formats the factory expects are taken from internal GDS spreadsheets (linked from the pivotal ticket, not publicly viewable), to ease our job when we wire in CSV loading.

It also adds a `RotaWeekBuilder`, which returns a `RotaWeek` collection, which conforms to the following rules:
1. No more than 1 person from the same team
2. At least 1 person with production access (that isn't web operations)
3. Has 2 developers and 1 web operations person on it

We were not able to implement:
1. No more than 1 tech lead at a time -- a canonical source of who is and is not a tech lead does not appear to be available.
2. Rotate people fairly. This will be added in a future PR.

These are suggestions for future enhancements.

**How to review**
Commit-by-commit review -- this is the first addition of 'real' behaviour for this application.

with @kalleth 
