### PR TITLE
Write CSV Parser to return correctly formatted data

### DIFF
--- a/lib/csv_parser.rb
+++ b/lib/csv_parser.rb
@@ -1,0 +1,43 @@
+require 'csv'
+
+class CSVParser
+  def initialize(people_string, deploy_access_string)
+    @people_string = people_string
+    @deploy_access_string = deploy_access_string
+  end
+
+  def people_data
+    parsed_csv_data(@people_string).map do |parsed_person|
+      parsed_person[:rota_skill_group] = normalize_skill_group(parsed_person)
+      parsed_person
+    end
+
+  end
+
+  def deploy_access_data
+    parsed_csv_data(@deploy_access_string).map do |parsed_person|
+      {:use_name => parsed_person.fetch(:use_name)}
+    end
+  end
+
+private
+
+  def normalize_skill_group(parsed_person)
+    SKILL_GROUPS.fetch(parsed_person[:rota_skill_group])
+  end
+
+  def parsed_csv_data(string)
+    csv = CSV.new(
+      string,
+      :headers           => true,
+      :header_converters => :symbol,
+    )
+    csv.to_a.map {|row| row.to_hash }
+  end
+
+  SKILL_GROUPS = {
+    "Dev"        => "developer",
+    "Dev (Supp)" => "developer",
+    "Web Ops"    => "webops",
+  }
+end

--- a/lib/rota_week_builder.rb
+++ b/lib/rota_week_builder.rb
@@ -47,7 +47,6 @@ private
     end
     result.select { |p| p.rota_skill_group == role }
   end
-
 end
 
 class RotaWeek

--- a/spec/csv_parser_spec.rb
+++ b/spec/csv_parser_spec.rb
@@ -1,0 +1,82 @@
+require "csv_parser"
+
+describe CSVParser do
+  let(:people_input_csv) {
+<<-EOF
+Full Name,Use Name,Rota Skill Group,Team
+"Doe, Jane",Jane D,Dev,PDU
+"Smith, John",John S,Dev (Supp),Product Gaps
+"Bloggs, Joe",Joe B,Dev,Infrastructure
+"Fenton, Peter",Peter F,Web Ops,Product Gaps
+EOF
+  }
+  let(:deploy_access_input_csv) {
+<<-EOF
+Full Name,Use Name,Rota Skill Group,Team
+"Doe, Jane",Jane D,Dev,PDU
+EOF
+  }
+
+  let(:desired_people_data) {
+    [
+      {
+        full_name: "Doe, Jane",
+        use_name: "Jane D",
+        rota_skill_group: "developer",
+        team: "PDU",
+      },
+      {
+        full_name: "Smith, John",
+        use_name: "John S",
+        rota_skill_group: "developer",
+        team: "Product Gaps",
+      },
+      {
+        full_name: "Bloggs, Joe",
+        use_name: "Joe B",
+        rota_skill_group: "developer",
+        team: "Infrastructure",
+      },
+      {
+        full_name: "Fenton, Peter",
+        use_name: "Peter F",
+        rota_skill_group: "webops",
+        team: "Product Gaps",
+      },
+    ]
+  }
+
+  let(:desired_deploy_access_data) {
+    [
+      {
+        use_name: "Jane D",
+      },
+    ]
+  }
+
+  subject(:parser) { described_class.new(people_input_csv, deploy_access_input_csv) }
+
+  it "correctly normalizes the rota_skill_group" do
+    people = parser.people_data
+
+    uniq_skill_groups = people.map { |p| p[:rota_skill_group] }.uniq
+
+    jane_d = people.find { |p| p[:use_name] == "Jane D" }
+    john_s = people.find { |p| p[:use_name] == "John S" }
+    peter_f = people.find { |p| p[:use_name] == "Peter F" }
+
+    expect(uniq_skill_groups).to eq(["developer", "webops"])
+
+    expect(jane_d[:rota_skill_group]).to eq("developer")
+    expect(john_s[:rota_skill_group]).to eq("developer")
+    expect(peter_f[:rota_skill_group]).to eq("webops")
+  end
+
+  it "returns correct people data" do
+    expect(parser.people_data).to eq(desired_people_data)
+  end
+
+  it "returns correct deploy access data" do
+    expect(parser.deploy_access_data).to eq(desired_deploy_access_data)
+  end
+end


### PR DESCRIPTION
Takes CSV input as strings
Exposes two methods: `people_data` and `deploy_access_data`
Normalises skill group names
