### PR TITLE
Bin script to run call_rota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.2
+
+This adds a bin script to run call_rota from the command line.
+
+This parses people and production_access CSV files and writes to a specified output file.
+
 ## 0.0.1
 
 This adds a PeopleCollectionFactory responsible for taking in two hashes containing available information about people -- their basic information (including job role), and whether or not they have production access.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    call-rota (0.0.1)
+    call-rota (0.0.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -29,18 +29,12 @@ following certain rules:
 No external services.
 
 The input format has been designed to match the current data from the Google
-Spreadsheets used at GDS to manage on-call rotas.
+Spreadsheets used at GDS to manage on-call rotas. For examples of the input format, see `spec/fixtures`.
 
 ##Running the application
 
-```ruby
-require 'people_collection_factory'
-require 'rota_week_builder'
-
-#people_inputs and deploy_access_inputs in the format described below
-people = PeopleCollectionFactory.new(people_inputs, deploy_access_inputs)
-
-rota_week = RotaWeekBuilder.new(people).call
+```
+bin/call_rota --people people.csv --production_access production_access.csv --output /tmp/output.csv
 ```
 
 ##Running the test suite
@@ -80,9 +74,6 @@ production access. Each element must follow the below format:
 
 ##Future work
 
-* Add CSV parsing for input data.
-* Add CSV output.
-* Add bin script to run the application.
 * Add rule: no more than 1 tech lead at a time -- a canonical source of who is
   and is not a tech lead does not appear to be available yet.
 * Rotate people fairly: this requires historical knowledge of who has been on

--- a/bin/call_rota
+++ b/bin/call_rota
@@ -1,7 +1,10 @@
 #!/usr/bin/env ruby
 $LOAD_PATH << File.expand_path("../lib/", File.dirname(__FILE__))
 
-require 'optparse'
+require "optparse"
+require "csv"
+require "call_rota_generator"
+
 options = Hash.new
 
 opt_parse = OptionParser.new do |opts|
@@ -11,28 +14,39 @@ opt_parse = OptionParser.new do |opts|
     options[:people] = file
   end
 
-  opts.on('--production_access', 'Production CSV file') do |file|
+  opts.on('--production_access FILE', 'Production CSV file') do |file|
     options[:production] = file
   end
 
-  opts.on('--output', 'Output CSV file') do |file|
+  opts.on('--output FILE', 'Output CSV file') do |file|
     options[:output] = file
   end
 end.parse!
 
+error_encountered = false
+
 unless options[:people]
   $stderr.puts "Please specify a --people argument with a people CSV file path"
-  exit(1)
+  error_encountered = true
 end
 
 unless options[:production]
   $stderr.puts "Please specify a --production_access argument with a people with production access CSV file path"
-  exit(1)
+  error_encountered = true
 end
 
 unless options[:output]
   $stderr.puts "Please specify a --output argument with an output CSV file path"
-  exit(1)
+  error_encountered = true
 end
+
+rota_week = CallRotaGenerator.new(options).call
+
+CSV.open(options[:output], "w+") do |csv|
+  csv << ["webops","dev","supplemental_dev"]
+  csv << [rota_week.web_ops, rota_week.dev, rota_week.supplemental_dev].map(&:use_name)
+end
+
+exit(1) if error_encountered
 
 exit(0)

--- a/bin/call_rota
+++ b/bin/call_rota
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+$LOAD_PATH << File.expand_path("../lib/", File.dirname(__FILE__))
+
+require 'optparse'
+options = Hash.new
+
+opt_parse = OptionParser.new do |opts|
+  opts.banner = "Usage: call_rota [options] output_path"
+
+  opts.on('--people FILE', 'People CSV file') do |file|
+    options[:people] = file
+  end
+
+  opts.on('--production_access', 'Production CSV file') do |file|
+    options[:production] = file
+  end
+
+  opts.on('--output', 'Output CSV file') do |file|
+    options[:output] = file
+  end
+end.parse!
+
+unless options[:people]
+  $stderr.puts "Please specify a --people argument with a people CSV file path"
+  exit(1)
+end
+
+unless options[:production]
+  $stderr.puts "Please specify a --production_access argument with a people with production access CSV file path"
+  exit(1)
+end
+
+unless options[:output]
+  $stderr.puts "Please specify a --output argument with an output CSV file path"
+  exit(1)
+end
+
+exit(0)

--- a/call-rota.gemspec
+++ b/call-rota.gemspec
@@ -12,7 +12,9 @@ Gem::Specification.new do |s|
   s.authors     = ["Tom Russell", "Camille Baldock"]
   s.homepage    = "https://github.com/alphagov/call-rota"
   s.email       = 'bradley.wright@digital.cabinet-office.gov.uk'
-  s.files       = Dir["{app,lib}/**/*"] + ["LICENSE", "README.md"]
+  s.files       = Dir["{app,lib,bin}/**/*"] + ["LICENSE", "README.md", "CHANGELOG.md"]
+  s.executables = ["call_rota"]
+  s.bindir      = "bin"
   s.test_files    = Dir["{spec}/**/*"]
   s.require_paths = ["lib"]
   s.license       = 'MIT'

--- a/lib/call_rota/version.rb
+++ b/lib/call_rota/version.rb
@@ -1,3 +1,3 @@
 module CallRota
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/lib/call_rota_generator.rb
+++ b/lib/call_rota_generator.rb
@@ -1,0 +1,37 @@
+require "csv_parser"
+require "people_collection_factory"
+require "rota_week_builder"
+
+class CallRotaGenerator
+  def initialize(options)
+    @options = options
+  end
+
+  def call
+    RotaWeekBuilder.new(people_collection).call
+  end
+
+private
+  def options
+    @options
+  end
+
+  def people_string
+    File.read(options[:people])
+  end
+
+  def production_access_string
+    File.read(options[:production])
+  end
+
+  def csv_parser
+    @parser ||= CSVParser.new(people_string, production_access_string)
+  end
+
+  def people_collection
+    PeopleCollectionFactory.new(
+      csv_parser.people_data,
+      csv_parser.production_access_data,
+    ).call
+  end
+end

--- a/lib/csv_parser.rb
+++ b/lib/csv_parser.rb
@@ -32,7 +32,7 @@ private
       :headers           => true,
       :header_converters => :symbol,
     )
-    csv.to_a.map {|row| row.to_hash }
+    csv.to_a.map { |row| row.to_hash }
   end
 
   SKILL_GROUPS = {

--- a/lib/csv_parser.rb
+++ b/lib/csv_parser.rb
@@ -1,9 +1,9 @@
 require 'csv'
 
 class CSVParser
-  def initialize(people_string, deploy_access_string)
+  def initialize(people_string, production_access_string)
     @people_string = people_string
-    @deploy_access_string = deploy_access_string
+    @production_access_string = production_access_string
   end
 
   def people_data
@@ -14,8 +14,8 @@ class CSVParser
 
   end
 
-  def deploy_access_data
-    parsed_csv_data(@deploy_access_string).map do |parsed_person|
+  def production_access_data
+    parsed_csv_data(@production_access_string).map do |parsed_person|
       {:use_name => parsed_person.fetch(:use_name)}
     end
   end

--- a/lib/people_collection_factory.rb
+++ b/lib/people_collection_factory.rb
@@ -1,16 +1,16 @@
 require "ostruct"
 
 class PeopleCollectionFactory
-  def initialize(people_inputs, deploy_access_inputs)
+  def initialize(people_inputs, production_access_inputs)
     @people_inputs = people_inputs
-    @people_with_deploy_access = production_access_use_names(deploy_access_inputs)
+    @people_with_production_access = production_access_use_names(production_access_inputs)
   end
 
   def call
     @people_inputs.map do |person_hash|
       build_person(
         person_hash,
-        deploy_access?(person_hash[:use_name]),
+        production_access?(person_hash[:use_name]),
       )
     end
   end
@@ -22,11 +22,11 @@ private
     )
   end
 
-  def production_access_use_names(raw_deploy_access_inputs)
-    raw_deploy_access_inputs.map { |p| p[:use_name] }
+  def production_access_use_names(raw_production_access_inputs)
+    raw_production_access_inputs.map { |p| p[:use_name] }
   end
 
-  def deploy_access?(person_use_name)
-    @people_with_deploy_access.include? person_use_name
+  def production_access?(person_use_name)
+    @people_with_production_access.include? person_use_name
   end
 end

--- a/spec/csv_parser_spec.rb
+++ b/spec/csv_parser_spec.rb
@@ -10,7 +10,7 @@ Full Name,Use Name,Rota Skill Group,Team
 "Fenton, Peter",Peter F,Web Ops,Product Gaps
 EOF
   }
-  let(:deploy_access_input_csv) {
+  let(:production_access_input_csv) {
 <<-EOF
 Full Name,Use Name,Rota Skill Group,Team
 "Doe, Jane",Jane D,Dev,PDU
@@ -46,7 +46,7 @@ EOF
     ]
   }
 
-  let(:desired_deploy_access_data) {
+  let(:desired_production_access_data) {
     [
       {
         use_name: "Jane D",
@@ -54,7 +54,7 @@ EOF
     ]
   }
 
-  subject(:parser) { described_class.new(people_input_csv, deploy_access_input_csv) }
+  subject(:parser) { described_class.new(people_input_csv, production_access_input_csv) }
 
   it "correctly normalizes the rota_skill_group" do
     people = parser.people_data
@@ -76,7 +76,7 @@ EOF
     expect(parser.people_data).to eq(desired_people_data)
   end
 
-  it "returns correct deploy access data" do
-    expect(parser.deploy_access_data).to eq(desired_deploy_access_data)
+  it "returns correct production access data" do
+    expect(parser.production_access_data).to eq(desired_production_access_data)
   end
 end

--- a/spec/fixtures/people.csv
+++ b/spec/fixtures/people.csv
@@ -1,0 +1,5 @@
+Full Name,Use Name,Rota Skill Group,Team
+"Doe, Jane",Jane D,Dev,PDU
+"Smith, John",John S,Dev (Supp),Product Gaps
+"Bloggs, Joe",Joe B,Dev,Infrastructure
+"Fenton, Peter",Peter F,Web Ops,Product Gaps

--- a/spec/fixtures/production_access.csv
+++ b/spec/fixtures/production_access.csv
@@ -1,0 +1,2 @@
+Full Name,Use Name,Rota Skill Group,Team
+"Doe, Jane",Jane D,Dev,PDU

--- a/spec/integration/call_rota_script_spec.rb
+++ b/spec/integration/call_rota_script_spec.rb
@@ -1,0 +1,48 @@
+require 'open3'
+
+describe "bin/call_rota" do
+  let(:people_fixture_path) { "spec/fixtures/people.csv" }
+  let(:production_access_fixture_path) { "spec/fixtures/production_access.csv" }
+  # let(:output_file_path) { Tempfile.new.path }
+  let(:output_file_path) { "/tmp/output.csv" }
+
+  it "fails if no people file is provided" do
+    parameters = "--production_access #{production_access_fixture_path} #{output_file_path}"
+    stderr, exit_status = run_script(parameters)
+
+    expect(exit_status).to be 1
+    expect(stderr).to match(/Please specify a --people argument/)
+  end
+
+  it "fails if no production_access file is provided" do
+    parameters = "--people #{people_fixture_path} #{output_file_path}"
+    stderr, exit_status = run_script(parameters)
+
+    expect(exit_status).to be 1
+    expect(stderr).to match(/Please specify a --production_access argument/)
+  end
+
+  it "fails if no output file is provided" do
+    parameters = "--people #{people_fixture_path} --production_access #{production_access_fixture_path}"
+    stderr, exit_status = run_script(parameters)
+
+    expect(exit_status).to be 1
+    expect(stderr).to match(/Please specify a --output argument/)
+  end
+
+  def run_script(parameters)
+    cmd = "bin/call_rota #{parameters}"
+
+    stderr = nil
+    stdout = nil
+    exit_status = nil
+
+    Open3.popen3(cmd) do |_, out, err, wait_thr|
+      stdout = out.read
+      stderr = err.read
+      exit_status = wait_thr.value.exitstatus
+    end
+
+    [stderr, exit_status]
+  end
+end

--- a/spec/integration/call_rota_script_spec.rb
+++ b/spec/integration/call_rota_script_spec.rb
@@ -1,13 +1,22 @@
 require 'open3'
+require 'csv'
+require 'tempfile'
 
 describe "bin/call_rota" do
   let(:people_fixture_path) { "spec/fixtures/people.csv" }
   let(:production_access_fixture_path) { "spec/fixtures/production_access.csv" }
-  # let(:output_file_path) { Tempfile.new.path }
-  let(:output_file_path) { "/tmp/output.csv" }
+  let(:output_file) { Tempfile.new('output.csv') }
+  let(:output_file_path) { output_file.path }
+  let(:valid_parameters) {
+    [
+      "--people #{people_fixture_path}",
+      "--production_access #{production_access_fixture_path}",
+      "--output #{output_file_path}",
+    ].join(" ")
+  }
 
   it "fails if no people file is provided" do
-    parameters = "--production_access #{production_access_fixture_path} #{output_file_path}"
+    parameters = "--production_access #{production_access_fixture_path} --output #{output_file_path}"
     stderr, exit_status = run_script(parameters)
 
     expect(exit_status).to be 1
@@ -15,7 +24,7 @@ describe "bin/call_rota" do
   end
 
   it "fails if no production_access file is provided" do
-    parameters = "--people #{people_fixture_path} #{output_file_path}"
+    parameters = "--people #{people_fixture_path} --output #{output_file_path}"
     stderr, exit_status = run_script(parameters)
 
     expect(exit_status).to be 1
@@ -30,9 +39,34 @@ describe "bin/call_rota" do
     expect(stderr).to match(/Please specify a --output argument/)
   end
 
+  it "generates an output file" do
+    _, exit_status = run_script(valid_parameters)
+
+    expect(exit_status).to be 0
+    expect(File.zero?(output_file_path)).not_to be(true)
+  end
+
+  it "has three valid entries" do
+    run_script(valid_parameters)
+    output = output_csv_data
+
+    expect(output.size).to be(1)
+    expect(output.first.keys).to eq([:webops, :dev, :supplemental_dev])
+  end
+
+  def output_csv_data
+    raw_data = File.read(output_file_path)
+    csv = CSV.new(
+      raw_data,
+      :headers           => true,
+      :header_converters => :symbol,
+    )
+
+    csv.to_a.map { |row| row.to_hash }
+  end
+
   def run_script(parameters)
     cmd = "bin/call_rota #{parameters}"
-
     stderr = nil
     stdout = nil
     exit_status = nil

--- a/spec/people_collection_factory_spec.rb
+++ b/spec/people_collection_factory_spec.rb
@@ -29,7 +29,7 @@ describe PeopleCollectionFactory do
     ]
   }
 
-  let(:deploy_access_input_data) {
+  let(:production_access_input_data) {
     [
       red_penguin_hash,
     ]
@@ -38,7 +38,7 @@ describe PeopleCollectionFactory do
   subject(:factory) {
     described_class.new(
       people_input_data,
-      deploy_access_input_data
+      production_access_input_data
     )
   }
 


### PR DESCRIPTION
To be review commit by commit.

This adds a bin script to run call_rota from the command line.
This parses people and production_access CSV files and writes to a specified output file.
